### PR TITLE
retsnoop: depends on calib_feat

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -76,7 +76,7 @@ $(OUTPUT)/%.o: %.c $(wildcard *.h) | $(OUTPUT) $(OUTPUT)/tests
 	$(Q)$(CC) $(CFLAGS) $(INCLUDES) -c $(filter %.c,$^) -o $@
 
 $(OUTPUT)/retsnoop.skel.h: $(OUTPUT)/mass_attach.bpf.o
-$(OUTPUT)/retsnoop.o: $(OUTPUT)/retsnoop.skel.h
+$(OUTPUT)/retsnoop.o: $(OUTPUT)/retsnoop.skel.h $(OUTPUT)/calib_feat.skel.h
 $(OUTPUT)/mass_attacher.o: $(OUTPUT)/retsnoop.skel.h $(OUTPUT)/calib_feat.skel.h
 
 $(OUTPUT)/addr2line.embed.o: ../tools/addr2line


### PR DESCRIPTION
Make sure calib_feat.skel.h is already there when compile retsnoop.c.

Signed-off-by: Thinker Lee <thinker.li@gmail.com>