### PR TITLE
retsnoop: sidecar accepts verbs in requests

### DIFF
--- a/src/addr2line.c
+++ b/src/addr2line.c
@@ -179,7 +179,7 @@ int addr2line__symbolize(const struct addr2line *a2l, long addr, struct a2l_resp
 {
 	int err, cnt = 0;
 
-	err = fprintf(a2l->write_pipe, "%lx\n", addr);
+	err = fprintf(a2l->write_pipe, "symbolize %lx\n", addr);
 	if (err <= 0) {
 		err = -errno;
 		fprintf(stderr, "Failed to symbolize %lx: %d\n", addr, err);


### PR DESCRIPTION
The sidecar is going to provide various features.  To support that,
 every request have to be prefixed with a verb to designate what
 function it requests.

This change is on the top of PR3.