### PR TITLE
Add functions defined in compile unit(s) to the list of globs

### DIFF
--- a/sidecar/Cargo.lock
+++ b/sidecar/Cargo.lock
@@ -12,6 +12,7 @@ dependencies = [
  "fallible-iterator",
  "findshlibs",
  "gimli",
+ "glob",
  "memmap",
  "object",
  "rustc-test",
@@ -178,6 +179,12 @@ dependencies = [
  "fallible-iterator",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hermit-abi"

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 addr2line = { version = "0.17.0", features=["std-object"] }
 gimli = { version = "0.26", default-features = false, features = ["read"] }
+glob = "0.3.0"
 fallible-iterator = { version = "0.2", default-features = false }
 memmap = "0.7"
 clap = "2"

--- a/sidecar/src/main.rs
+++ b/sidecar/src/main.rs
@@ -40,6 +40,23 @@ enum Addrs<'a> {
     Stdin(Lines<StdinLock<'a>>),
 }
 
+fn conv_linux_src_loc<'a>(path: &'a str) -> &'a str {
+    let linux_dirs = [
+	"arch/", "kernel/", "include/", "block/", "fs/", "net/",
+	"drivers/", "mm/", "ipc/", "security/", "lib/", "crypto/",
+	"certs/", "init/", "lib/", "scripts/", "sound/", "tools/",
+	"usr/", "virt/",
+    ];
+
+    for cur_dir in linux_dirs {
+        match path.find(cur_dir) {
+            Some(pos) => return &path[pos..],
+            _ => ()
+        }
+    }
+    path
+}
+
 impl<'a> Iterator for Addrs<'a> {
     type Item = QueryType;
 
@@ -222,7 +239,7 @@ fn query_compile_unit<T: gimli::Endianity>(
         }
         let name = unit.name.unwrap();
         let name = name.to_string().expect("name of a compile unit");
-        if !cu_pattern.matches(name) {
+        if !cu_pattern.matches(conv_linux_src_loc(name)) {
             continue;
         }
 

--- a/sidecar/src/main.rs
+++ b/sidecar/src/main.rs
@@ -15,6 +15,7 @@ use clap::{App, Arg, ArgMatches, Values};
 use fallible_iterator::FallibleIterator;
 use object::{Object, ObjectSection, SymbolMap, SymbolMapName};
 use typed_arena::Arena;
+use glob;
 
 use addr2line::{Context, Location};
 
@@ -211,6 +212,7 @@ fn query_compile_unit<T: gimli::Endianity>(
     ctx: &Context<gimli::EndianSlice<T>>,
     _config: &Config,
 ) {
+    let cu_pattern = glob::Pattern::new(compile_unit).unwrap();
     let dwarf = ctx.dwarf();
     let mut units = dwarf.units();
     while let Some(header) = units.next().expect("fail to parse units") {
@@ -220,7 +222,7 @@ fn query_compile_unit<T: gimli::Endianity>(
         }
         let name = unit.name.unwrap();
         let name = name.to_string().expect("name of a compile unit");
-        if !name.eq(compile_unit) {
+        if !cu_pattern.matches(name) {
             continue;
         }
 

--- a/src/addr2line.c
+++ b/src/addr2line.c
@@ -217,3 +217,8 @@ int addr2line__symbolize(const struct addr2line *a2l, long addr, struct a2l_resp
 	return cnt;
 }
 
+int addr2line__query_symbols(const struct addr2line *a2l, const char *compile_unit, struct a2l_resp *resp)
+{
+	return -ENOTSUP;
+}
+

--- a/src/addr2line.h
+++ b/src/addr2line.h
@@ -9,11 +9,18 @@ struct a2l_resp
 	char line[512];
 };
 
+struct a2l_cu_resp
+{
+	char fname[128 - sizeof(void*)]; /* Reduce fragment */
+	void* address;
+};
+
 struct addr2line;
 
 struct addr2line *addr2line__init(const char *vmlinux, bool inlines);
 void addr2line__free(struct addr2line *a2l);
 
 int addr2line__symbolize(const struct addr2line *a2l, long addr, struct a2l_resp *resp);
+int addr2line__query_symbols(const struct addr2line *a2l, const char *compile_unit, struct a2l_cu_resp **resp_ret);
 
 #endif /* __ADDR2LINE_H */

--- a/src/retsnoop.c
+++ b/src/retsnoop.c
@@ -195,6 +195,11 @@ cleanup:
 	return err;
 }
 
+static int append_compile_unit(char ***strs, int *cnt, const char *compile_unit)
+{
+	return -ENOTSUP;
+}
+
 static int append_pid(int **pids, int *cnt, const char *arg)
 {
 	void *tmp;
@@ -273,29 +278,35 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 	case 'a':
 		if (arg[0] == '@') {
 			err = append_str_file(&env.allow_globs, &env.allow_glob_cnt, arg + 1);
-			if (err)
-				return err;
-		} else if (append_str(&env.allow_globs, &env.allow_glob_cnt, arg)) {
-			return -ENOMEM;
+		} else if (arg[0] == ':') {
+			err = append_compile_unit(&env.allow_globs, &env.allow_glob_cnt, arg + 1);
+		} else {
+			err = append_str(&env.allow_globs, &env.allow_glob_cnt, arg);
 		}
+		if (err)
+			return err;
 		break;
 	case 'd':
 		if (arg[0] == '@') {
 			err = append_str_file(&env.deny_globs, &env.deny_glob_cnt, arg + 1);
-			if (err)
-				return err;
-		} else if (append_str(&env.deny_globs, &env.deny_glob_cnt, arg)) {
-			return -ENOMEM;
+		} else if (arg[0] == ':') {
+			err = append_compile_unit(&env.deny_globs, &env.deny_glob_cnt, arg + 1);
+		} else {
+			err = append_str(&env.deny_globs, &env.deny_glob_cnt, arg);
 		}
+		if (err)
+			return err;
 		break;
 	case 'e':
 		if (arg[0] == '@') {
 			err = append_str_file(&env.entry_globs, &env.entry_glob_cnt, arg + 1);
-			if (err)
-				return err;
-		} else if (append_str(&env.entry_globs, &env.entry_glob_cnt, arg)) {
-			return -ENOMEM;
+		} else if (arg[0] == ':') {
+			err = append_compile_unit(&env.entry_globs, &env.entry_glob_cnt, arg + 1);
+		} else {
+			err = append_str(&env.entry_globs, &env.entry_glob_cnt, arg);
 		}
+		if (err)
+			return err;
 		break;
 	case 's':
 		env.symb_lines = true;


### PR DESCRIPTION
By prefixing ':' before the name of a compile unit, all functions defined in the compile unit will be added to the specified list of globs.  For example, giving '-a :path/to/XXX.c', all functions defined in XXX.c will be added to the allow list.

