### PR TITLE
Add explicit target to sidecar/Cargo.toml

### DIFF
--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -17,3 +17,7 @@ findshlibs = "0.10"
 rustc-test = "0.3"
 typed-arena = "2"
 object = { version = "0.27.1", default-features = false, features = ["read"]}
+
+[[bin]]
+name = "addr2line"
+path = "src/main.rs"


### PR DESCRIPTION
`cargo read-manifest` needs this, and this is used by Fedora's Rust
macros to generate the list of dependencies.

Signed-off-by: Michel Alexandre Salim <salimma@fedoraproject.org>