### PR TITLE
Fix arm64 build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -11,7 +11,7 @@ LIBBPF_OBJ := $(abspath $(OUTPUT)/libbpf.a)
 # outdated
 INCLUDES := -I$(OUTPUT) -I../libbpf/include/uapi
 CFLAGS := -g -Wall -O0
-ARCH := $(shell uname -m | sed 's/x86_64/x86/')
+ARCH := $(shell uname -m | sed 's/x86_64/x86/g; s/aarch64/arm64/g')
 
 # Get Clang's default includes on this system. We'll explicitly add these dirs
 # to the includes list when compiling with `-target bpf` because otherwise some

--- a/src/calib_feat.bpf.c
+++ b/src/calib_feat.bpf.c
@@ -34,7 +34,7 @@ int calib_entry(struct pt_regs *ctx)
 	/* Used for kretprobe function entry IP discovery, before
 	 * bpf_get_func_ip() helper was added.
 	 */
-	entry_ip = ctx->ip - 1;
+	entry_ip = PT_REGS_IP(ctx) - 1;
 
 	/* Detect if bpf_get_func_ip() helper is supported by the kernel.
 	 * Added in: 9b99edcae5c8 ("bpf: Add bpf_get_func_ip helper for tracing programs")

--- a/src/mass_attach.bpf.c
+++ b/src/mass_attach.bpf.c
@@ -95,7 +95,7 @@ int kentry(struct pt_regs *ctx)
 	if (has_bpf_get_func_ip)
 		ip = bpf_get_func_ip(ctx);
 	else
-		ip = ctx->ip - 1;
+		ip = PT_REGS_IP(ctx) - 1;
 
 	if (has_bpf_cookie) {
 		id = bpf_get_attach_cookie(ctx);


### PR DESCRIPTION
Currently retsnoop doesn't work in my arm64 machine as it reports
`uname -a` as aarch64,

Also update the instruction pointer accessor to use some BTF goodness,
as arm uses `user_pt_regs` instead of `pt_regs`.

BTW, thanks for this tool! It's incredibly useful and works great! ❤️ Will throw
away all my custom bpftrace scripts to do half of what this tool does. Would
send you a #thanks if I could :)