### PR TITLE
fix default error message keyword for presets (and add -c ? for list)

### DIFF
--- a/src/retsnoop.c
+++ b/src/retsnoop.c
@@ -1914,7 +1914,7 @@ int main(int argc, char **argv)
 
 	if (env.entry_glob_cnt == 0) {
 		fprintf(stderr, "No entry point globs specified. "
-				"Please provide entry glob(s) ('-e GLOB') and/or any preset ('-p PRESET').\n");
+				"Please provide entry glob(s) ('-e GLOB') and/or any preset ('-c PRESET').\n");
 		return -1;
 	}
 


### PR DESCRIPTION
Just playing with this after link from HN, and error confused me by saying -p PRESET. Probably ought to fix that :)

I'm not adamant on `-c ?`, feel free to only take the first patch -- it's just the first way I could think of to get the list without looking at the code. Turned out there were less than I thought so it's probably not very useful for most people right now, but assuming more presets get added it could become handy?
