### PR TITLE
Bump dependencies

### DIFF
--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-addr2line = { version = "0.17.0", features=["std-object"] }
+addr2line = { version = "0.18", features=["std-object"] }
 gimli = { version = "0.26", default-features = false, features = ["read"] }
 glob = "0.3.0"
 fallible-iterator = { version = "0.2", default-features = false }
@@ -16,7 +16,7 @@ backtrace = "0.3.13"
 findshlibs = "0.10"
 rustc-test = "0.3"
 typed-arena = "2"
-object = { version = "0.27.1", default-features = false, features = ["read"]}
+object = { version = "0.29", default-features = false, features = ["read"]}
 
 [[bin]]
 name = "addr2line"


### PR DESCRIPTION
Two of the dependencies are outdated; retsnoop builds fine with the latest on Fedora 37 and rawhide x86_64

Signed-off-by: Michel Alexandre Salim <michel@michel-slm.name>