### PR TITLE
retsnoop: fix non-x86 IP reg when no BPF_FUNC_get_func_ip

### DIFF
--- a/src/calib_feat.bpf.c
+++ b/src/calib_feat.bpf.c
@@ -33,7 +33,14 @@ int calib_entry(struct pt_regs *ctx)
 	/* Used for kretprobe function entry IP discovery, before
 	 * bpf_get_func_ip() helper was added.
 	 */
+#ifdef bpf_target_x86
+	/* for x86 the IP is off by one at hardware level,
+	 * see https://github.com/anakryiko/retsnoop/issues/32
+	 */
 	entry_ip = PT_REGS_IP(ctx) - 1;
+#else
+	entry_ip = PT_REGS_IP(ctx);
+#endif
 
 	/* Detect if bpf_get_func_ip() helper is supported by the kernel.
 	 * Added in: 9b99edcae5c8 ("bpf: Add bpf_get_func_ip helper for tracing programs")

--- a/src/mass_attach.bpf.c
+++ b/src/mass_attach.bpf.c
@@ -91,10 +91,18 @@ int kentry(struct pt_regs *ctx)
 	if (!ready)
 		return 0;
 
-	if (has_bpf_get_func_ip)
+	if (has_bpf_get_func_ip) {
 		ip = bpf_get_func_ip(ctx);
-	else
+	} else {
+#ifdef bpf_target_x86
+		/* for x86 the IP is off by one at hardware level,
+		 * see https://github.com/anakryiko/retsnoop/issues/32
+		 */
 		ip = PT_REGS_IP(ctx) - 1;
+#else
+		ip = PT_REGS_IP(ctx);
+#endif
+	}
 
 	if (has_bpf_cookie) {
 		id = bpf_get_attach_cookie(ctx);


### PR DESCRIPTION
----------

newer kernels with BPF_FUNC_get_func_ip can get a correct value with bpf_get_func_ip, but for older kernels we look directly at the hardware ip reg and it appears to only be off by one on x86 architectures.

Make the `- 1` we use to find function pointers architecture dependant to fix non-x86 runs.

Tested by forcing has_bpf_get_func_ip to false.

Fixes: #32

------------------

Took me a bit more than a week, sorry for the delay.
We don't seem to have any arch-specific code in retsnoop itself (most of it is in libbpf/src/bpf_tracing.h which is part of libbpf) so I wasn't sure what to use, but PT_REGS_IP is actually defined in bpf_tracing.h so we can use the defines set there. If you can think of something better happy to adjust anything.

I've tested on x86_64 with a newer kernel by manually adjusting the toggle, and on older aarch64.