### PR TITLE
retsnoop: add io_uring/ linux_dir and resort all the others

### DIFF
--- a/src/retsnoop.c
+++ b/src/retsnoop.c
@@ -918,10 +918,10 @@ static int filter_kstack(struct ctx *ctx, struct kstack_item *r, const struct ca
 static int detect_linux_src_loc(const char *path)
 {
 	static const char *linux_dirs[] = {
-		"arch/", "kernel/", "include/", "block/", "fs/", "net/",
-		"drivers/", "mm/", "ipc/", "security/", "lib/", "crypto/",
-		"certs/", "init/", "lib/", "scripts/", "sound/", "tools/",
-		"usr/", "virt/", 
+		"arch/", "block/", "certs/", "crypto/", "drivers/", "fs/",
+		"include/", "init/", "io_uring/", "ipc/", "kernel/", "lib/",
+		"mm/", "net/", "rust/", "scripts/", "security/", "sound/",
+		"tools/", "usr/", "virt/",
 	};
 	int i;
 	char *p;


### PR DESCRIPTION
io_uring is now in the root of Linux repo, so add it into linux_dirs table.

Signed-off-by: Andrii Nakryiko <andrii@kernel.org>