### PR TITLE
Add release workflow for shipping binaries and combined sources

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,97 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build:
+    name: Build static retsnoop binary
+    runs-on: ubuntu-22.04
+    env:
+      TARGETARCH: ${{ matrix.arch }}
+      FILE_STRING_ARCH_amd64: x86-64
+      FILE_STRING_ARCH_arm64: aarch64
+    strategy:
+      matrix:
+        arch: [arm64, amd64]
+
+    steps:
+      # amd64 needs the dependencies to build retsnoop
+      - name: Install dependencies (amd64)
+        if: matrix.arch == 'amd64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cargo llvm libelf-dev
+
+      - name: Checkout retsnoop code
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+        with:
+          submodules: recursive
+          path: 'retsnoop'
+
+      - name: Build static retsnoop natively for amd64
+        if: matrix.arch == 'amd64'
+        working-directory: 'retsnoop'
+        run: |
+          CFLAGS=--static \
+              make -j -C src V=1
+          strip src/retsnoop
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+        if: matrix.arch == 'arm64'
+        with:
+          platforms: arm64
+
+      # The emulated build leverages Docker and Ubuntu 22.04 container image
+      # distribution to have all the needed arm64 packages.
+      - name: Build static retsnoop for arm64 with emulation
+        if: matrix.arch == 'arm64'
+        run:  |
+          docker run --platform linux/arm64 --rm -v $(pwd):/build ubuntu:22.04 \
+          bash -c "apt-get update && \
+                   apt-get install -y cargo clang llvm make pkg-config gcc \
+                       libelf-dev zlib1g-dev && \
+                   cd /build/retsnoop && \
+                   CFLAGS=--static \
+                       make -j -C src V=1 && \
+                   strip src/retsnoop"
+
+      - name: Test retsnoop binary
+        working-directory: 'retsnoop/src'
+        env:
+          ARCH: ${{ env[format('FILE_STRING_ARCH_{0}', matrix.arch)] }}
+        run: |
+          file ./retsnoop | \
+              tee /dev/stderr | \
+              grep -q "${{ env.ARCH }}"
+          ./retsnoop --usage | grep -q Usage
+          ldd ./retsnoop 2>&1 | \
+              tee /dev/stderr | \
+              grep -q 'not a dynamic executable'
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: ${{ format('retsnoop_{0}', matrix.arch) }}
+          path: retsnoop/src/retsnoop
+
   draft-release:
     name: Create a draft release
     runs-on: ubuntu-22.04
+    needs: build
     permissions:
       contents: write
     steps:
+      - name: Download artifacts from build
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+
+      - name: Rename binaries and compress
+        run: |
+          archive_amd64="retsnoop-${{ github.ref_name }}-amd64.tar.gz"
+          archive_arm64="retsnoop-${{ github.ref_name }}-arm64.tar.gz"
+          tar -C retsnoop_amd64 -I 'gzip -9' -cvf "${archive_amd64}" retsnoop
+          tar -C retsnoop_arm64 -I 'gzip -9' -cvf "${archive_arm64}" retsnoop
+          sha256sum "${archive_amd64}" > "${archive_amd64}.sha256sum"
+          sha256sum "${archive_arm64}" > "${archive_arm64}.sha256sum"
+
       - name: Checkout retsnoop and submodules code
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: release
+
+on:
+  push:
+    tags:
+      - '**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.after }}
+  cancel-in-progress: true
+
+jobs:
+  draft-release:
+    name: Create a draft release
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout retsnoop and submodules code
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+        with:
+          submodules: recursive
+          path: 'retsnoop'
+
+      - name: Package source code including submodules
+        run: |
+          tar -I 'gzip -9' --exclude-vcs \
+              -cvf "srcs-full-${{ github.ref_name }}.tar.gz" retsnoop
+          zip -9 -x '*.git' -x '*.git/*' \
+              -r "srcs-full-${{ github.ref_name }}.zip" retsnoop
+
+      - name: Create draft release and add artifacts
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
+        with:
+          draft: true
+          files: |
+            retsnoop*
+            srcs-full-*

--- a/scripts/gh-label-release-assets.sh
+++ b/scripts/gh-label-release-assets.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BSD-2-Clause
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Use this script to add labels to GitHub release assets for a given release.
+#
+# Based on the following console workflow:
+#
+# gh api \
+#     '/repos/anakryiko/retsnoop/releases/tags/<some_tag>' \
+#     --jq '.id'
+# gh api \
+#     '/repos/anakryiko/retsnoop/releases/<release_id>/assets' \
+#     --jq '.[] | select(.name == "<file_name>").id'
+# gh api \
+#     --method PATCH \
+#     -H "Accept: application/vnd.github+json" \
+#     -H "X-GitHub-Api-Version: 2022-11-28" \
+#     '/repos/anakryiko/retsnoop/releases/assets/<asset_id>' \
+#     -f name='<new_file_name>' \
+#     -f label='<new_name_in_asset_list>'
+
+REPO="anakryiko/retsnoop"
+
+usage() {
+    echo "Update asset labels for retsnoop releases"
+    echo "Usage:"
+    echo "  $0 [options] <release_tag>"
+    echo ""
+    echo "OPTIONS"
+    echo " -h       display this help"
+    exit "$1"
+}
+
+OPTIND=1
+while getopts "h" opt; do
+    case "$opt" in
+    h)
+        usage 0
+        ;;
+    *)
+        usage 1
+        ;;
+    esac
+done
+shift $((OPTIND-1))
+[[ "${1:-}" = "--" ]] && shift
+
+# Get release tag from command line
+if [[ "$#" -lt 1 ]]; then
+    echo "error: missing release tag"
+    usage 1
+fi
+release_tag="$1"
+echo "repo: ${REPO}, release tag: ${release_tag}"
+
+# Add labels to set for given asset names here:
+declare -A assets_labels=(
+    ["srcs-full-${release_tag}.tar.gz"]="Full source code with submodules (tar.gz)"
+    ["srcs-full-${release_tag}.zip"]="Full source code with submodules (zip)"
+)
+
+# Get release ID
+release_id="$(gh api "/repos/${REPO}/releases/tags/${release_tag}" --jq '.id')"
+echo "  found release ID ${release_id}"
+
+# For each label to set, get asset ID, prompt user for confirmation, set label
+for asset_name in "${!assets_labels[@]}"; do
+    asset_id="$(gh api "/repos/${REPO}/releases/${release_id}/assets" \
+        --jq ".[] | select(.name == \"${asset_name}\").id")"
+    echo "  found asset ID ${asset_id}"
+
+    echo "asset '${asset_name}': add label '${assets_labels[${asset_name}]}'"
+    answer=""
+    read -rp 'proceed? [y/N]: ' answer
+
+    case "${answer}" in
+        y|yes|Y|Yes|YES)
+            # Note: A 404 error at this stage may be synonymous with
+            # insufficient permissions for the token in use for gh.
+            gh api \
+                --method PATCH \
+                -H 'Accept: application/vnd.github+json' \
+                -H 'X-GitHub-Api-Version: 2022-11-28' \
+                "/repos/${REPO}/releases/assets/${asset_id}" \
+                -f label="${assets_labels[${asset_name}]}"
+            ;;
+        *)
+            echo "cancelled"
+            ;;
+    esac
+done


### PR DESCRIPTION
Same as for [veristat](https://github.com/libbpf/veristat/pull/5). Minor differences include:

- Script under `BSD-2-Clause` rather than dual license, to match with the rest of the repository
- Using `$(CFLAGS)` and not `$(EXTRA_CFLAGS)` to pass `--static`

Note that compiling the binary on arm64 takes much longer in the case of retsnoop, apparently because of the Rust tool: it took 20 minutes for my test run (vs. ~2min for amd64).

Test release [available here](https://github.com/qmonnet/retsnoop/releases/tag/test01).