### PR TITLE
Release workflow: Use GH Action for packaging sources, cross-compile addr2line on host

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,11 @@ jobs:
         include:
           - arch: amd64
             file_str: x86-64
+            target: x86_64-unknown-linux-gnu
 
           - arch: arm64
             file_str: aarch64
+            target: aarch64-unknown-linux-gnu
 
     steps:
       # amd64 needs the dependencies to build retsnoop
@@ -44,6 +46,25 @@ jobs:
               make -j -C src V=1
           strip src/retsnoop
 
+      - name: (arm64) Pre-compile Rust sidecar binary, addr2line
+        if: matrix.arch == 'arm64'
+        working-directory: 'retsnoop/sidecar'
+        run: |
+          # It's too expensive to compile addr2line inside of the Docker
+          # container, below: Cargo's registry index update gets OOM-killed,
+          # and even if we worked around that, the build would take about three
+          # times as long as doing it on the host.
+          #
+          # We need the right toolchain and linker, then we can compile.
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          rustup target add ${{ matrix.target }}
+          CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse \
+              cargo build --release --target ${{ matrix.target }} \
+                  --config target.${{ matrix.target }}.linker=\"aarch64-linux-gnu-gcc\"
+          # Makefile expects the binary in retsnoop/sidecar/target/release/
+          mv target/${{ matrix.target }}/release/addr2line target/release/
+
       - name: (arm64) Set up QEMU
         uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
         if: matrix.arch == 'arm64'
@@ -57,9 +78,10 @@ jobs:
         run: |
           docker run --platform linux/arm64 --rm -v $(pwd):/build ubuntu:22.04 \
               bash -c "apt-get update && \
-                       apt-get install -y cargo clang llvm make pkg-config gcc \
+                       apt-get install -y clang llvm make pkg-config gcc \
                            libelf-dev zlib1g-dev && \
                        cd /build/retsnoop && \
+                       CARGO=true \
                        CFLAGS=--static \
                            make -j -C src V=1 && \
                        strip src/retsnoop"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,17 +13,18 @@ jobs:
   build:
     name: Build static retsnoop binary
     runs-on: ubuntu-22.04
-    env:
-      TARGETARCH: ${{ matrix.arch }}
-      FILE_STRING_ARCH_amd64: x86-64
-      FILE_STRING_ARCH_arm64: aarch64
     strategy:
       matrix:
-        arch: [arm64, amd64]
+        include:
+          - arch: amd64
+            file_str: x86-64
+
+          - arch: arm64
+            file_str: aarch64
 
     steps:
       # amd64 needs the dependencies to build retsnoop
-      - name: Install dependencies (amd64)
+      - name: (amd64) Install dependencies
         if: matrix.arch == 'amd64'
         run: |
           sudo apt-get update
@@ -35,7 +36,7 @@ jobs:
           submodules: recursive
           path: 'retsnoop'
 
-      - name: Build static retsnoop natively for amd64
+      - name: (amd64) Build static retsnoop natively
         if: matrix.arch == 'amd64'
         working-directory: 'retsnoop'
         run: |
@@ -43,34 +44,32 @@ jobs:
               make -j -C src V=1
           strip src/retsnoop
 
-      - name: Set up QEMU
+      - name: (arm64) Set up QEMU
         uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
         if: matrix.arch == 'arm64'
         with:
-          platforms: arm64
+          platforms: ${{ matrix.arch }}
 
       # The emulated build leverages Docker and Ubuntu 22.04 container image
       # distribution to have all the needed arm64 packages.
-      - name: Build static retsnoop for arm64 with emulation
+      - name: (arm64) Build static retsnoop for arm64 with emulation
         if: matrix.arch == 'arm64'
-        run:  |
+        run: |
           docker run --platform linux/arm64 --rm -v $(pwd):/build ubuntu:22.04 \
-          bash -c "apt-get update && \
-                   apt-get install -y cargo clang llvm make pkg-config gcc \
-                       libelf-dev zlib1g-dev && \
-                   cd /build/retsnoop && \
-                   CFLAGS=--static \
-                       make -j -C src V=1 && \
-                   strip src/retsnoop"
+              bash -c "apt-get update && \
+                       apt-get install -y cargo clang llvm make pkg-config gcc \
+                           libelf-dev zlib1g-dev && \
+                       cd /build/retsnoop && \
+                       CFLAGS=--static \
+                           make -j -C src V=1 && \
+                       strip src/retsnoop"
 
       - name: Test retsnoop binary
         working-directory: 'retsnoop/src'
-        env:
-          ARCH: ${{ env[format('FILE_STRING_ARCH_{0}', matrix.arch)] }}
         run: |
           file ./retsnoop | \
               tee /dev/stderr | \
-              grep -q "${{ env.ARCH }}"
+              grep -q "${{ matrix.file_str }}"
           ./retsnoop --usage | grep -q Usage
           ldd ./retsnoop 2>&1 | \
               tee /dev/stderr | \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,11 +108,12 @@ jobs:
           path: 'retsnoop'
 
       - name: Package source code including submodules
-        run: |
-          tar -I 'gzip -9' --exclude-vcs \
-              -cvf "srcs-full-${{ github.ref_name }}.tar.gz" retsnoop
-          zip -9 -x '*.git' -x '*.git/*' \
-              -r "srcs-full-${{ github.ref_name }}.zip" retsnoop
+        uses: qmonnet/git-archive-all-action@791fb850881cf58b1d1fcc9b06c01940080bba0a # v1.0.1
+        with:
+          output-files: >-
+            srcs-full-${{ github.ref_name }}.tar.gz
+            srcs-full-${{ github.ref_name }}.zip
+          base-repo: retsnoop
 
       - name: Create draft release and add artifacts
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15


### PR DESCRIPTION
This PR updates the release workflow to use a dedicated GitHub Action for packaging the source files for retsnoop _and_ its submodules. Contrarily to the previous commands, this Action should take into account the `export-ignore` directives from the `.gitattributes` files. Although it may not show immediately for the libbpf submodule, because we need https://github.com/libbpf/libbpf/commit/3f591a66103d49b311956618d440a84cf4d30715 to be synced before that.

When testing the change above, I observed that the job for building the arm54 binary would no longer pass. This is due to the Rust registry index update getting OOM-killed in the Docker container that we use to cross-compile. I'm not sure what caused this change, but I found a way to address it: by cross-compiling `addr2line` directly on the host, we solve the memory issue, and we cut down the duration of the job from ~20 to ~6 minutes.

- [Test run](https://github.com/qmonnet/retsnoop/actions/runs/5127792954)
- [Test release](https://github.com/qmonnet/retsnoop/releases/tag/test05)