### PR TITLE
retsnoop: Use bpf_probe_read_kernel() instead of bpf_probe_read()

### DIFF
--- a/src/calib_feat.bpf.c
+++ b/src/calib_feat.bpf.c
@@ -104,7 +104,7 @@ int calib_exit(struct pt_regs *ctx)
 	asm volatile ("%[fp] = r10" : [fp] "+r"(fp) :);
 
 	for (i = 1; i <= MAX_ATTEMPTS; i++) {
-		bpf_probe_read(&tk, sizeof(tk), (void *)(fp + i * sizeof(__u64)));
+		bpf_probe_read_kernel(&tk, sizeof(tk), (void *)(fp + i * sizeof(__u64)));
 		ip = (__u64)BPF_CORE_READ(tk, rp.kp.addr);
 
 		if (ip == entry_ip) {

--- a/src/mass_attach.bpf.c
+++ b/src/mass_attach.bpf.c
@@ -49,7 +49,7 @@ static __always_inline u64 get_kret_func_ip(void *ctx)
 		/* get frame pointer */
 		asm volatile ("%[fp] = r10" : [fp] "+r"(fp) :);
 
-		bpf_probe_read(&tk, sizeof(tk), (void *)(fp + kret_ip_off * sizeof(__u64)));
+		bpf_probe_read_kernel(&tk, sizeof(tk), (void *)(fp + kret_ip_off * sizeof(__u64)));
 		ip = (__u64)BPF_CORE_READ(tk, rp.kp.addr);
 		return ip;
 	}

--- a/src/retsnoop.bpf.c
+++ b/src/retsnoop.bpf.c
@@ -112,9 +112,9 @@ static __noinline void save_stitch_stack(void *ctx, struct call_stack *stack)
 
 	/* we can stitch together stack subsections */
 	if (stack->saved_depth && stack->max_depth + 1 == stack->saved_depth) {
-		bpf_probe_read(stack->saved_ids + d, len * sizeof(stack->saved_ids[0]), stack->func_ids + d);
-		bpf_probe_read(stack->saved_res + d, len * sizeof(stack->saved_res[0]), stack->func_res + d);
-		bpf_probe_read(stack->saved_lat + d, len * sizeof(stack->saved_lat[0]), stack->func_lat + d);
+		bpf_probe_read_kernel(stack->saved_ids + d, len * sizeof(stack->saved_ids[0]), stack->func_ids + d);
+		bpf_probe_read_kernel(stack->saved_res + d, len * sizeof(stack->saved_res[0]), stack->func_res + d);
+		bpf_probe_read_kernel(stack->saved_lat + d, len * sizeof(stack->saved_lat[0]), stack->func_lat + d);
 		stack->saved_depth = stack->depth + 1;
 		if (extra_verbose)
 			bpf_printk("STITCHED STACK %d..%d to ..%d\n",
@@ -132,9 +132,9 @@ static __noinline void save_stitch_stack(void *ctx, struct call_stack *stack)
 			   stack->saved_depth, stack->saved_max_depth, stack->depth + 1);
 	}
 
-	bpf_probe_read(stack->saved_ids + d, len * sizeof(stack->saved_ids[0]), stack->func_ids + d);
-	bpf_probe_read(stack->saved_res + d, len * sizeof(stack->saved_res[0]), stack->func_res + d);
-	bpf_probe_read(stack->saved_lat + d, len * sizeof(stack->saved_lat[0]), stack->func_lat + d);
+	bpf_probe_read_kernel(stack->saved_ids + d, len * sizeof(stack->saved_ids[0]), stack->func_ids + d);
+	bpf_probe_read_kernel(stack->saved_res + d, len * sizeof(stack->saved_res[0]), stack->func_res + d);
+	bpf_probe_read_kernel(stack->saved_lat + d, len * sizeof(stack->saved_lat[0]), stack->func_lat + d);
 
 	stack->saved_depth = stack->depth + 1;
 	stack->saved_max_depth = stack->max_depth;


### PR DESCRIPTION
Fix retsnoop on the architectures with the overlapping kernel and user spaces, e.g., s390x.