### PR TITLE
retsnoop: Pass the real envp to the sidecar

### DIFF
--- a/src/addr2line.h
+++ b/src/addr2line.h
@@ -17,7 +17,7 @@ struct a2l_cu_resp
 
 struct addr2line;
 
-struct addr2line *addr2line__init(const char *vmlinux, long stext_addr, bool verbose, bool inlines);
+struct addr2line *addr2line__init(const char *vmlinux, long stext_addr, bool verbose, bool inlines, char **envp);
 void addr2line__free(struct addr2line *a2l);
 
 long addr2line__kaslr_offset(const struct addr2line *a2l);

--- a/src/retsnoop.c
+++ b/src/retsnoop.c
@@ -1929,7 +1929,7 @@ static void sig_handler(int sig)
 	exiting = true;
 }
 
-int main(int argc, char **argv)
+int main(int argc, char **argv, char **envp)
 {
 	long page_size = sysconf(_SC_PAGESIZE);
 	struct mass_attacher_opts att_opts = {};
@@ -2009,7 +2009,7 @@ int main(int argc, char **argv)
 			symb_inlines = true;
 
 		env.ctx.a2l = addr2line__init(env.vmlinux_path ?: vmlinux_path, stext_sym->addr,
-					      env.verbose, symb_inlines);
+					      env.verbose, symb_inlines, envp);
 		if (!env.ctx.a2l) {
 			fprintf(stderr, "Failed to start addr2line for vmlinux image at %s!\n",
 				env.vmlinux_path ?: vmlinux_path);


### PR DESCRIPTION
In child_driver when addr2line binary is getting prepared, it's getting executed with an empty envp. This could lead to issues if the environment is messed up and retsnoop was started with envp, specifically constructed to fix this (think of libraries visibility for example).

Do an extra mile and carry around the original provided envp to pass it into fexecve.