### PR TITLE
retsnoop: remove hard-coded maximum of 256 CPUs supported

### DIFF
--- a/src/retsnoop.h
+++ b/src/retsnoop.h
@@ -3,9 +3,6 @@
 #ifndef __RETSNOOP_H
 #define __RETSNOOP_H
 
-#define MAX_CPUS 256
-#define MAX_CPUS_MSK (MAX_CPUS - 1)
-
 #define MAX_FUNC_NAME_LEN 40
 
 #define MAX_FSTACK_DEPTH 64


### PR DESCRIPTION
Dynamically determine number of CPUs and size BPF-side data accordingly. This removes previously hard-coded limitation of supporting machines with only up to 256 cores.