### PR TITLE
retsnoop: fix sign extension failure logic

### DIFF
--- a/src/retsnoop.h
+++ b/src/retsnoop.h
@@ -55,6 +55,8 @@ struct call_stack {
 	long lbrs_sz;
 
 	int next_seq_id;
+
+	long scratch; /* for obfuscating pointers to be read as integers */
 };
 
 struct func_trace_start {


### PR DESCRIPTION
If we decide that function is returning 32-bit integer (which is a default case when we can't get BTF information about the function, so this would be common right now for kernel module functions), we should truncate actual returned value (captured as u64) to 32-bit u32 before doing the comparisons inside IS_ERR_VALUE32().

This potentially could break some cases in fentry/fexit (-F) mode with pointer-returning functions (which is explained in the comment inside IS_ERR_VALUE32()), but those should be determined as pointer-returning from BTF information, and will be handled with IS_ERR_VALUE().

Reported-by: Maxim Samoylov <max7255@meta.com>