### PR TITLE
ci: mark release workflow as `workflow_dispatch`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: release
 
-on:
-  push:
-    tags:
-      - '**'
+on: workflow_dispatch
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.after }}


### PR DESCRIPTION
According to Github Actions, this should allow to trigger the workflow manually. Let's see.

Cc: Quentin Monnet <quentin@isovalent.com>