### PR TITLE
bpftool: Pass additional compile flags as EXTRA_CFLAGS, not CFLAGS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,73 @@
+name: build
+
+on: pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build retsnoop binary
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            file_str: x86-64
+            target: x86_64-unknown-linux-gnu
+
+    steps:
+      - name: (amd64) Install dependencies
+        if: matrix.arch == 'amd64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cargo llvm libelf-dev
+
+      - name: Checkout retsnoop code
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+        with:
+          submodules: recursive
+          path: 'retsnoop'
+
+      - name: (amd64) Build retsnoop
+        if: matrix.arch == 'amd64'
+        working-directory: 'retsnoop'
+        run: |
+          make -j -C src V=1
+          strip src/retsnoop
+
+      - name: Test retsnoop binary
+        working-directory: 'retsnoop/src'
+        run: |
+          file ./retsnoop | \
+              tee /dev/stderr | \
+              grep -q "${{ matrix.file_str }}"
+          ./retsnoop --usage | grep -q Usage
+          ldd ./retsnoop 2>&1 | \
+              tee /dev/stderr | \
+              grep -q 'libc.so'
+
+      - name: Clean up
+        working-directory: 'retsnoop'
+        run: |
+          make -C src clean
+
+      - name: (amd64) Build static retsnoop
+        if: matrix.arch == 'amd64'
+        working-directory: 'retsnoop'
+        run: |
+          CFLAGS=--static \
+              make -j -C src V=1
+          strip src/retsnoop
+
+      - name: Test retsnoop binary
+        working-directory: 'retsnoop/src'
+        run: |
+          file ./retsnoop | \
+              tee /dev/stderr | \
+              grep -q "${{ matrix.file_str }}"
+          ./retsnoop --usage | grep -q Usage
+          ldd ./retsnoop 2>&1 | \
+              tee /dev/stderr | \
+              grep -q 'not a dynamic executable'

--- a/src/Makefile
+++ b/src/Makefile
@@ -96,9 +96,10 @@ $(LIBBPF_OBJ): $(wildcard $(LIBBPF_SRC)/*.[ch] $(LIBBPF_SRC)/Makefile) | $(OUTPU
 $(BPFTOOL): $(LIBBPF_OBJ) | $(BPFTOOL_OUTPUT)
 	$(call msg,BPFTOOL,$@)
 	$(Q) [ -d ../bpftool/src ] || git submodule update --init
-	$(Q)$(MAKE) ARCH= CROSS_COMPILE=				      \
-		    BPF_DIR=$(LIBBPF_SRC) OUTPUT=$(BPFTOOL_OUTPUT)/	      \
-		    -C $(BPFTOOL_SRC) bootstrap
+	$(Q)CFLAGS= EXTRA_CFLAGS="$(CFLAGS)"				      \
+		$(MAKE) ARCH= CROSS_COMPILE=				      \
+			BPF_DIR=$(LIBBPF_SRC) OUTPUT=$(BPFTOOL_OUTPUT)/	      \
+			-C $(BPFTOOL_SRC) bootstrap
 
 bpftool: $(BPFTOOL)
 	$(Q)ln -s $(BPFTOOL) bpftool


### PR DESCRIPTION
Bpftool expects users to pass additional compilation flags via `EXTRA_CFLAGS`, not via `CFLAGS`. This is because when compiled from the kernel repo, `CFLAGS` are usually overwritten by the build system.

When we build retsnoop with `CFLAGS=--static`, the static flag is passed down to bpftool's `Makefile`. Then we hit an issue: `--static` is ignored for feature probing at build time, but taken into account for the build itself. Under certain conditions this results in a discrepency and bpftool's `Makefile` believes LLVM support is available (given it tested without the `--static` flag) whereas it is not set up for static builds.

Let's address this by passing retsnoop's `CFLAGS` via bpftool's `EXTRA_CFLAGS`, and resetting its `CFLAGS`. We must pass the `CFLAGS` to the "make" invocation through the environment, and not as a command line argument, to avoid overriding the `CFLAGS` values that we set inside of bpftool's `Makefile`.

Related: https://github.com/anakryiko/retsnoop/pull/51#issuecomment-1741953868
