### PR TITLE
Makefile: Update variables for package builds with external artifacts

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -11,8 +11,9 @@ BPFTOOL_OUTPUT ?= $(abspath $(OUTPUT)/bpftool)
 BPFTOOL ?= $(BPFTOOL_OUTPUT)/bootstrap/bpftool
 
 LIBBPF_SRC := $(abspath ../libbpf/src)
-LIBBPF_OBJ := $(abspath $(OUTPUT)/libbpf.a)
-SIDECAR := ../sidecar/target/$(if $(DEBUG),debug,release)/addr2line
+LIBBPF_OBJ ?= $(abspath $(OUTPUT)/libbpf.a)
+SIDECAR ?= ../sidecar/target/$(if $(DEBUG),debug,release)/addr2line
+SIDECAR_EMBED_NAME ?= $(subst .,_,$(subst /,_,$(SIDECAR)))
 # Use our own libbpf API headers and Linux UAPI headers distributed with
 # libbpf to avoid dependency on system-wide headers, which could be missing or
 # outdated
@@ -34,7 +35,7 @@ endif
 
 # for installation
 INSTALL := install
-prefix := /usr/local
+prefix ?= /usr/local
 bindir := $(prefix)/bin
 
 # Get Clang's default includes on this system. We'll explicitly add these dirs
@@ -136,9 +137,9 @@ $(OUTPUT)/addr2line.embed.o: $(SIDECAR)
 	$(Q)$(LLVM_STRIP) -g $<
 	$(call msg,LD,$@)
 	$(Q)$(LD) -r -b binary -z noexecstack \
-		--defsym __binary_sidecar_start=_binary____sidecar_target_$(if $(DEBUG),debug,release)_addr2line_start \
-		--defsym __binary_sidecar_end=_binary____sidecar_target_$(if $(DEBUG),debug,release)_addr2line_end \
-		--defsym __binary_sidecar_size=_binary____sidecar_target_$(if $(DEBUG),debug,release)_addr2line_size \
+		--defsym __binary_sidecar_start=_binary_$(SIDECAR_EMBED_NAME)_start \
+		--defsym __binary_sidecar_end=_binary_$(SIDECAR_EMBED_NAME)_end \
+		--defsym __binary_sidecar_size=_binary_$(SIDECAR_EMBED_NAME)_size \
 		-o $@ $<
 
 $(OUTPUT)/addr2line.o: $(OUTPUT)/addr2line.embed.o


### PR DESCRIPTION
Hi!

I'm still using retsnoop once in a while and needed it at home (nixos), so figured I'd package it there.

First commit is mostly unrelated -- the link command ought to use LDFLAGS and not CFLAGS. Keeping CFLAGS doesn't really hurt but shouldn't be required so I removed it, happy to use both flags instead as long as LDFLAGS are added.


The second commit is a bit more complicated: Nixos requires the build to not use internet, so I need to build the addr2line sidecar crate with a frozen cargo command independently of the rest -- that's internal nixos mess and I'm not expecting any help here, but I also had problem with the sidecar ld command in the past (#31 -- actually that'd need an extra subst for `-` -> `_`, I wonder if make has a better syntax for this, sure couldn't find it... At least that can be overwritten with an env var now), so the SIDECAR_LDPATH might make that a bit simpler to use and at least ought to clarify where that magic symbol comes from.

Similarly, nixos libbpf package provides a libbpf.a, so we're more or less supposed to use it unless there's a very good reason not to -- the libbpf package is kept up to date and while the submodule is a bit more up to date than 1.3.0 I haven't seen any problem with the latest release so far.
I know what you're thinking about not using the submodule and I'm sure that'll come bite me at some point, but I'm expecting libbpf to have stabilized enough to be manageable since 1.0, so the worst that can happen is probably me bugging you for a new libbpf release if you tag a new retsnoop release that requires a new call from libbpf, and libbpf itself isn't getting updated. Hopefully not too often :)


The last commit is complete garbage, but I couldn't come up with a way to flag that I don't want to rebuild the sidecar (the `::` make target will always try to run cargo and that'll fail for me); I think I'll just patch it on the nixos side but bringing it up here if you have a better idea.

With all of this, I can build retsnoop by just setting a few env vars as follow (after building addr2line and copying it to the current directory):
```
    LIBBPF_OBJ=${libbpf}/lib/libbpf.a \
      BPFTOOL=${lib.getExe bpftool} \
      SIDECAR=addr2line \
      make
```



There's no hurry on anything here, just tell me what you think we can keep when you have a moment and I'll clean up a bit, and I'll submit the nixos package when that's done.