### PR TITLE
Makefile: use LDFLAGS for linking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,7 @@ jobs:
         if: matrix.arch == 'amd64'
         working-directory: 'retsnoop'
         run: |
+          # LDFLAGS here would also apply to bpftool which fails to build with static
           CFLAGS=--static \
               make -j -C src V=1
           strip src/retsnoop

--- a/src/Makefile
+++ b/src/Makefile
@@ -158,7 +158,7 @@ retsnoop: $(addprefix $(OUTPUT)/,					\
 		      mass_attacher.o)					\
 	  $(LIBBPF_OBJ)
 	$(call msg,BINARY,$@)
-	$(Q)$(CC) $(CFLAGS) $^ -lelf -lz -o $@
+	$(Q)$(CC) $(CFLAGS) $(LDFLAGS) $^ -lelf -lz -o $@
 
 $(OUTPUT)/tests/simfail.o: $(OUTPUT)/tests/kprobe_bad_kfunc.skel.h	\
 			   $(OUTPUT)/tests/fentry_unsupp_func.skel.h	\
@@ -169,7 +169,7 @@ simfail: $(addprefix $(OUTPUT)/tests/,					\
 		     simfail.o)						\
 	  $(LIBBPF_OBJ)
 	$(call msg,BINARY,$@)
-	$(Q)$(CC) $(CFLAGS) $^ -lelf -lz -o $@
+	$(Q)$(CC) $(CFLAGS) $(LDFLAGS) $^ -lelf -lz -o $@
 
 # delete failed targets
 .DELETE_ON_ERROR:


### PR DESCRIPTION
(This is the first patch from #56)

The link rule normally uses LDFLAGS and not CFLAGS.

For backwards compatibility though keep both as compilers will just ignore compile flags when linking.

Also note that LDFLAGS would also apply to the bpftool build, which might cause problems if some flags intended for retsnoop cannot link with it (e.g. -static for bpftool requires more libraries to be available as .a); if that becomes a problem we might need a way to differentiate the two in the future.