### PR TITLE
Makefile: Do not rebuild the sidecar if not the default path

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -12,7 +12,8 @@ BPFTOOL ?= $(BPFTOOL_OUTPUT)/bootstrap/bpftool
 
 LIBBPF_SRC := $(abspath ../libbpf/src)
 LIBBPF_OBJ ?= $(abspath $(OUTPUT)/libbpf.a)
-SIDECAR ?= ../sidecar/target/$(if $(DEBUG),debug,release)/addr2line
+DEFAULT_SIDECAR := ../sidecar/target/$(if $(DEBUG),debug,release)/addr2line
+SIDECAR ?= $(DEFAULT_SIDECAR)
 SIDECAR_EMBED_NAME ?= $(subst .,_,$(subst /,_,$(SIDECAR)))
 # Use our own libbpf API headers and Linux UAPI headers distributed with
 # libbpf to avoid dependency on system-wide headers, which could be missing or
@@ -128,7 +129,7 @@ $(OUTPUT)/retsnoop.skel.h: $(OUTPUT)/mass_attach.bpf.o
 $(OUTPUT)/retsnoop.o: $(OUTPUT)/retsnoop.skel.h $(OUTPUT)/calib_feat.skel.h
 $(OUTPUT)/mass_attacher.o: $(OUTPUT)/retsnoop.skel.h $(OUTPUT)/calib_feat.skel.h
 
-$(SIDECAR)::
+$(DEFAULT_SIDECAR)::
 	$(call msg,CARGO,addr2line)
 	$(Q)$(CARGO) build --manifest-path=../sidecar/Cargo.toml $(if $(DEBUG),,--release)
 


### PR DESCRIPTION
(This is a follow-up on #56 -- it contains #56 itself as that'd conflict so leaving it as draft fo now)

If the SIDECAR variable has been overriden then running cargo is not
useful nor desired:
define a DEFAULT_SIDECAR variable we can compare against and only add
the `$(SIDECAR)::` rebuild rule if SIDECAR has the default value.

------------

>> The last commit is complete garbage, but I couldn't come up with a way to flag that I don't want to rebuild the sidecar (the :: make target will always try to run cargo and that'll fail for me); I think I'll just patch it on the nixos side but bringing it up here if you have a better idea.
>
> yeah, this is not good for "normal" build path. What we can do, perhaps, is to have DEFAULT_SIDECAR vs SIDECAR that can be overridden, and if they don't match, don't even trigger cargo (as it's pointless anyways). Let's do this as a separate PR still?

That makes a lot of sense, with the path changed it's not like cargo would be able to do anything useful anyway.

I've fiddled with it a bit and it appears to work with both default and non-default value in my environment.