### PR TITLE
Bump gimli stack

### DIFF
--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-addr2line = { version = "0.21", features=["std-object"] }
-gimli = { version = "0.28", default-features = false, features = ["read"] }
+addr2line = { version = "0.24" }
+gimli = { version = "0.31", default-features = false, features = ["read"] }
 glob = "0.3"
 fallible-iterator = { version = "0.3", default-features = false }
 memmap = "0.7"
@@ -15,7 +15,7 @@ clap = "2"
 backtrace = "0.3"
 findshlibs = "0.10"
 typed-arena = "2"
-object = { version = "0.32", default-features = false, features = ["read"]}
+object = { version = "0.36", default-features = false, features = ["read"]}
 
 [[bin]]
 name = "addr2line"


### PR DESCRIPTION
We're updating gimli / addr2line / object in Fedora to prepare for getting blazesym packaged, retsnoop can/should be updated to match