### PR TITLE
retsnoop: handle idle threads properly

### DIFF
--- a/src/fnargs.c
+++ b/src/fnargs.c
@@ -997,7 +997,7 @@ int prepare_ctx_args_specs(int probe_id, const struct inj_probe_info *inj)
 {
 	struct ctx_args_info *ctx_args;
 	char desc[256];
-	int i, err;
+	int i, err = -EINVAL;
 
 	snprintf_inj_probe(desc, sizeof(desc), inj);
 

--- a/src/logic.h
+++ b/src/logic.h
@@ -47,6 +47,7 @@ struct trace_item {
 };
 
 struct session {
+	int sess_id;
 	int pid;
 	int tgid;
 	uint64_t start_ts;

--- a/src/retsnoop.h
+++ b/src/retsnoop.h
@@ -130,6 +130,7 @@ struct ctxargs_info {
 struct rec_session_start {
 	/* REC_SESSION_START */
 	enum rec_type type;
+	int sess_id;
 	int pid;
 	int tgid;
 	long start_ts;
@@ -140,7 +141,7 @@ struct rec_func_trace_entry {
 	/* REC_FUNC_TRACE_ENTRY or REC_FUNC_TRACE_EXIT */
 	enum rec_type type;
 
-	int pid;
+	int sess_id;
 	long ts;
 
 	int seq_id;
@@ -154,7 +155,7 @@ struct rec_func_trace_entry {
 struct rec_fnargs_capture {
 	/* REC_FNARGS_CAPTURE */
 	enum rec_type type;
-	int pid;
+	int sess_id;
 	int seq_id;
 	unsigned short func_id;
 	unsigned short data_len;
@@ -166,7 +167,7 @@ struct rec_fnargs_capture {
 struct rec_ctxargs_capture {
 	/* REC_CTXARGS_CAPTURE */
 	enum rec_type type;
-	int pid;
+	int sess_id;
 	int seq_id;
 	unsigned short probe_id;
 	unsigned short data_len;
@@ -178,7 +179,7 @@ struct rec_ctxargs_capture {
 struct rec_lbr_stack {
 	/* REC_LBR_STACK */
 	enum rec_type type;
-	int pid;
+	int sess_id;
 
 	int lbrs_sz;
 	struct perf_branch_entry lbrs[MAX_LBR_ENTRIES];
@@ -187,7 +188,7 @@ struct rec_lbr_stack {
 struct rec_inj_probe {
 	/* REC_INJ_PROBE */
 	enum rec_type type;
-	int pid;
+	int sess_id;
 	long ts;
 
 	int seq_id;
@@ -224,7 +225,7 @@ struct call_stack {
 struct rec_session_end {
 	/* REC_SESSION_END */
 	enum rec_type type;
-	int pid;
+	int sess_id;
 	long emit_ts;
 	bool ignored;
 	bool is_err;


### PR DESCRIPTION
Idle threads all have PID 0, one idle thread per each CPU. This screws up retsnoop's logic around using PID as a unique session ID. So for idle threads, use -(1 + CPU ID) as a session (session ID 0 will be reserved as invalid).