### PR TITLE
retsnoop: avoid checking `if (sess->defunct)` twice

### DIFF
--- a/src/retsnoop.bpf.c
+++ b/src/retsnoop.bpf.c
@@ -675,9 +675,9 @@ static __noinline bool push_call_stack(void *ctx, u32 id, u64 ip)
 		}
 	}
 
-out_defunct:
 	/* if we failed to send out REC_SESSION_START, update depth and bail */
 	if (sess->defunct) {
+out_defunct:
 		sess->depth++;
 		return false;
 	}


### PR DESCRIPTION
This is suboptimal, but also, depending on compiler version, can generate code that would look like an infinite loop to the BPF verifier, apparently.

Closes: https://github.com/anakryiko/retsnoop/issues/79
Reported-by: Daniel Hodges <hodges.daniel.scott@gmail.com>