### PR TITLE
Replace the deprecated memmap with the maintained memmap2

### DIFF
--- a/sidecar/Cargo.lock
+++ b/sidecar/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
  "findshlibs",
  "gimli 0.31.1",
  "glob",
- "memmap",
+ "memmap2",
  "object",
  "typed-arena",
 ]
@@ -283,16 +283,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "memmap"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "memmap2"

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -10,7 +10,7 @@ addr2line = "0.24.2"
 gimli = { version = "0.31", default-features = false, features = ["read"] }
 glob = "0.3"
 fallible-iterator = { version = "0.3", default-features = false }
-memmap = "0.7"
+memmap2 = "0.9"
 clap = { version = "4", features = ["derive"] }
 backtrace = "0.3"
 findshlibs = "0.10"

--- a/sidecar/src/main.rs
+++ b/sidecar/src/main.rs
@@ -2,7 +2,7 @@ extern crate addr2line;
 extern crate clap;
 extern crate fallible_iterator;
 extern crate gimli;
-extern crate memmap;
+extern crate memmap2;
 extern crate object;
 extern crate typed_arena;
 
@@ -419,7 +419,7 @@ fn main() {
     let config = Config::parse();
 
     let file = File::open(&config.exe).unwrap();
-    let map = unsafe { memmap::Mmap::map(&file).unwrap() };
+    let map = unsafe { memmap2::Mmap::map(&file).unwrap() };
     let object = &object::File::parse(&*map).unwrap();
 
     let endian = if object.is_little_endian() {
@@ -435,7 +435,7 @@ fn main() {
     let sup_map;
     let sup_object = if let Some(sup_path) = config.sup.as_deref() {
         let sup_file = File::open(sup_path).unwrap();
-        sup_map = unsafe { memmap::Mmap::map(&sup_file).unwrap() };
+        sup_map = unsafe { memmap2::Mmap::map(&sup_file).unwrap() };
         Some(object::File::parse(&*sup_map).unwrap())
     } else {
         None


### PR DESCRIPTION
This is requested by the Rust SIG so we don't need to bring in deprecated dependencies into EPEL 10 and then maintain it for the lifetime of RHEL 10 (a decade plus)