### PR TITLE
Add arm64 support to fnargs.c

### DIFF
--- a/src/retsnoop.bpf.c
+++ b/src/retsnoop.bpf.c
@@ -215,7 +215,50 @@ static __always_inline u64 get_stack_pointer(void *ctx)
 
 	return sp;
 }
-#else /* !__TARGET_ARCH_x86 */
+#elif defined(__TARGET_ARCH_arm64)
+static u64 get_arg_reg_value(void *ctx, u32 arg_idx)
+{
+	if (use_kprobes) {
+		struct pt_regs *regs = ctx;
+
+		switch (arg_idx) {
+			case 0: return PT_REGS_PARM1(regs);
+			case 1: return PT_REGS_PARM2(regs);
+			case 2: return PT_REGS_PARM3(regs);
+			case 3: return PT_REGS_PARM4(regs);
+			case 4: return PT_REGS_PARM5(regs);
+			case 5: return PT_REGS_PARM6(regs);
+			case 6: return PT_REGS_PARM7(regs);
+			case 7: return PT_REGS_PARM8(regs);
+			default: return 0;
+		}
+	} else {
+		u64 *args = ctx, val;
+
+		bpf_probe_read_kernel(&val, sizeof(val), &args[arg_idx]);
+		return val;
+	}
+}
+
+static __always_inline u64 get_stack_pointer(void *ctx)
+{
+	u64 sp;
+
+	if (use_kprobes) {
+		sp = PT_REGS_SP((struct pt_regs *)ctx);
+		barrier_var(sp);
+	} else {
+		/* current FENTRY doesn't support attaching to functions that
+		 * pass arguments on the stack, so we don't really need to
+		 * implement this
+		 */
+		sp = 0;
+		barrier_var(sp);
+	}
+
+	return sp;
+}
+#else /* !__TARGET_ARCH_x86 && !__TARGET_ARCH_arm64 */
 static u64 get_arg_reg_value(void *ctx, u32 arg_idx) { return 0; }
 static u64 get_stack_pointer(void *ctx) { return 0; }
 #endif

--- a/src/retsnoop.c
+++ b/src/retsnoop.c
@@ -411,7 +411,7 @@ int main(int argc, char **argv, char **envp)
 	skel->rodata->use_kprobes = env.attach_mode != ATTACH_FENTRY;
 	memset(skel->rodata->spaces, ' ', sizeof(skel->rodata->spaces) - 1);
 
-#ifdef __x86_64__
+#if defined(__x86_64__) || defined(__aarch64__)
 	skel->rodata->capture_fn_args = env.capture_args;
 #else
 	skel->rodata->capture_fn_args = false;
@@ -527,7 +527,7 @@ int main(int argc, char **argv, char **envp)
 	}
 
 	if (env.capture_args) {
-#ifdef __x86_64__
+#if defined(__x86_64__) || defined(__aarch64__)
 		for (i = 0; i < func_cnt; i++) {
 			const struct mass_attacher_func_info *finfo;
 
@@ -539,7 +539,7 @@ int main(int argc, char **argv, char **envp)
 			}
 		}
 #else
-		vlog("Function arguments capture is only supported on x86-64 architecture!\n");
+		vlog("Function arguments capture is only supported on x86-64 and ARM64 architectures!\n");
 #endif
 	}
 
@@ -643,7 +643,7 @@ int main(int argc, char **argv, char **envp)
 		fi->ip = finfo->addr;
 		fi->flags = flags;
 
-#ifdef __x86_64__
+#if defined(__x86_64__) || defined(__aarch64__)
 		if (env.capture_args) {
 			const struct func_args_info *fn_args = func_args_info(i);
 
@@ -651,7 +651,7 @@ int main(int argc, char **argv, char **envp)
 				fi->arg_specs[j] = fn_args->arg_specs[j].arg_flags;
 			}
 		}
-#endif /* __x86_64__ */
+#endif /* __x86_64__ || __aarch64__ */
 	}
 
 	for (i = 0; i < env.entry_glob_cnt; i++) {

--- a/src/retsnoop.c
+++ b/src/retsnoop.c
@@ -411,7 +411,7 @@ int main(int argc, char **argv, char **envp)
 	skel->rodata->use_kprobes = env.attach_mode != ATTACH_FENTRY;
 	memset(skel->rodata->spaces, ' ', sizeof(skel->rodata->spaces) - 1);
 
-#if defined(__x86_64__) || defined(__aarch64__)
+#ifdef RETSNOOP_SUPPORTS_ARG_CAPTURE
 	skel->rodata->capture_fn_args = env.capture_args;
 #else
 	skel->rodata->capture_fn_args = false;
@@ -527,7 +527,7 @@ int main(int argc, char **argv, char **envp)
 	}
 
 	if (env.capture_args) {
-#if defined(__x86_64__) || defined(__aarch64__)
+#ifdef RETSNOOP_SUPPORTS_ARG_CAPTURE
 		for (i = 0; i < func_cnt; i++) {
 			const struct mass_attacher_func_info *finfo;
 
@@ -643,7 +643,7 @@ int main(int argc, char **argv, char **envp)
 		fi->ip = finfo->addr;
 		fi->flags = flags;
 
-#if defined(__x86_64__) || defined(__aarch64__)
+#ifdef RETSNOOP_SUPPORTS_ARG_CAPTURE
 		if (env.capture_args) {
 			const struct func_args_info *fn_args = func_args_info(i);
 
@@ -651,7 +651,7 @@ int main(int argc, char **argv, char **envp)
 				fi->arg_specs[j] = fn_args->arg_specs[j].arg_flags;
 			}
 		}
-#endif /* __x86_64__ || __aarch64__ */
+#endif /* RETSNOOP_SUPPORTS_ARG_CAPTURE */
 	}
 
 	for (i = 0; i < env.entry_glob_cnt; i++) {

--- a/src/retsnoop.h
+++ b/src/retsnoop.h
@@ -44,6 +44,11 @@ enum func_flags {
 };
 
 #define MAX_FNARGS_ARG_SPEC_CNT 12
+/* 
+ * Function argument capture is supported on:
+ * - x86-64: arguments in rdi, rsi, rdx, rcx, r8, r9 registers
+ * - ARM64: arguments in x0-x7 registers
+ */
 #define MAX_FNARGS_TOTAL_ARGS_SZ (64 * 1024)	/* maximum total captured args data size */
 #define MAX_FNARGS_SIZED_ARG_SZ (16 * 1024)	/* maximum capture size for a single fixed-sized arg */
 #define MAX_FNARGS_STR_ARG_SZ (16 * 1024)	/* maximum capture size for a signel string arg */

--- a/src/retsnoop.h
+++ b/src/retsnoop.h
@@ -49,6 +49,32 @@ enum func_flags {
  * - x86-64: arguments in rdi, rsi, rdx, rcx, r8, r9 registers
  * - ARM64: arguments in x0-x7 registers
  */
+
+#ifdef __x86_64__
+#define RETSNOOP_SUPPORTS_ARG_CAPTURE 1
+#define MAX_FNARGS_IN_REGS 6
+#define FNARGS_STACK_OFFSET 8 /* 8 bytes for return address */
+#define FNARGS_STACK_ALIGNMENT_MASK 7
+static const char *const REG_NAMES[MAX_FNARGS_IN_REGS] = {
+	"rdi", "rsi", "rdx", "rcx", "r8", "r9"
+};
+#elif defined(__aarch64__)
+#define RETSNOOP_SUPPORTS_ARG_CAPTURE 1
+#define MAX_FNARGS_IN_REGS 8
+/* From the AArch64 ABI Function Call Standard: "The next stacked argument
+ * address (NSAA) is set to the current stack-pointer value (SP)."
+ */
+#define FNARGS_STACK_OFFSET 0
+#define FNARGS_STACK_ALIGNMENT_MASK 15
+static const char *const REG_NAMES[MAX_FNARGS_IN_REGS] = {
+	"x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7"
+};
+#else
+#define MAX_FNARGS_IN_REGS 0
+#define FNARGS_STACK_OFFSET 0
+#define FNARGS_STACK_ALIGNMENT_MASK 0
+#endif
+
 #define MAX_FNARGS_TOTAL_ARGS_SZ (64 * 1024)	/* maximum total captured args data size */
 #define MAX_FNARGS_SIZED_ARG_SZ (16 * 1024)	/* maximum capture size for a single fixed-sized arg */
 #define MAX_FNARGS_STR_ARG_SZ (16 * 1024)	/* maximum capture size for a signel string arg */


### PR DESCRIPTION
The README states:

> NOTE: Function arguments capture feature is currently only supported on x86-64 (amd64) architecture. Most probably arm64 support will be added as well, please request this using Github issues, if you are interested in this.

I am interested in the above (as I'm in the middle of an ARM migration so the opportunity to trace on x86 hardware is slowly vanishing), but don't know how to implement it. However, I do have access to Cursor/Claude 3.7 and am curious as to how close it comes to getting this correct.

However, I won't be offended if the answer is "I don't have time to read random unflitered LLM output".