### PR TITLE
fnargs: follow up refactoring

### DIFF
--- a/src/retsnoop.bpf.c
+++ b/src/retsnoop.bpf.c
@@ -174,7 +174,6 @@ static __always_inline const struct ctxargs_info *ctxargs_info(u32 id)
 	return &ctxargs_infos[id & ctxargs_info_mask];
 }
 
-#if defined(__TARGET_ARCH_arm64) || defined(__TARGET_ARCH_x86)
 static __always_inline u64 get_stack_pointer(void *ctx)
 {
 	u64 sp;
@@ -194,7 +193,7 @@ static __always_inline u64 get_stack_pointer(void *ctx)
 	return sp;
 }
 
-#ifdef __TARGET_ARCH_x86
+#if defined(__TARGET_ARCH_x86)
 static u64 get_arg_reg_value(void *ctx, u32 arg_idx)
 {
 	if (use_kprobes) {
@@ -216,8 +215,6 @@ static u64 get_arg_reg_value(void *ctx, u32 arg_idx)
 		return val;
 	}
 }
-
-
 #elif defined(__TARGET_ARCH_arm64)
 static u64 get_arg_reg_value(void *ctx, u32 arg_idx)
 {
@@ -242,10 +239,8 @@ static u64 get_arg_reg_value(void *ctx, u32 arg_idx)
 		return val;
 	}
 }
-#endif
 #else /* !__TARGET_ARCH_x86 && !__TARGET_ARCH_arm64 */
 static u64 get_arg_reg_value(void *ctx, u32 arg_idx) { return 0; }
-static u64 get_stack_pointer(void *ctx) { return 0; }
 #endif
 
 static __always_inline u64 coerce_size(u64 val, int sz)

--- a/src/retsnoop.c
+++ b/src/retsnoop.c
@@ -411,7 +411,7 @@ int main(int argc, char **argv, char **envp)
 	skel->rodata->use_kprobes = env.attach_mode != ATTACH_FENTRY;
 	memset(skel->rodata->spaces, ' ', sizeof(skel->rodata->spaces) - 1);
 
-#ifdef RETSNOOP_SUPPORTS_ARG_CAPTURE
+#ifdef FNARGS_SUPPORT
 	skel->rodata->capture_fn_args = env.capture_args;
 #else
 	skel->rodata->capture_fn_args = false;
@@ -527,7 +527,7 @@ int main(int argc, char **argv, char **envp)
 	}
 
 	if (env.capture_args) {
-#ifdef RETSNOOP_SUPPORTS_ARG_CAPTURE
+#ifdef FNARGS_SUPPORT
 		for (i = 0; i < func_cnt; i++) {
 			const struct mass_attacher_func_info *finfo;
 
@@ -643,7 +643,7 @@ int main(int argc, char **argv, char **envp)
 		fi->ip = finfo->addr;
 		fi->flags = flags;
 
-#ifdef RETSNOOP_SUPPORTS_ARG_CAPTURE
+#ifdef FNARGS_SUPPORT
 		if (env.capture_args) {
 			const struct func_args_info *fn_args = func_args_info(i);
 
@@ -651,7 +651,7 @@ int main(int argc, char **argv, char **envp)
 				fi->arg_specs[j] = fn_args->arg_specs[j].arg_flags;
 			}
 		}
-#endif /* RETSNOOP_SUPPORTS_ARG_CAPTURE */
+#endif /* FNARGS_SUPPORT */
 	}
 
 	for (i = 0; i < env.entry_glob_cnt; i++) {

--- a/src/retsnoop.h
+++ b/src/retsnoop.h
@@ -51,28 +51,29 @@ enum func_flags {
  */
 
 #ifdef __x86_64__
-#define RETSNOOP_SUPPORTS_ARG_CAPTURE 1
-#define MAX_FNARGS_IN_REGS 6
-#define FNARGS_STACK_OFFSET 8 /* 8 bytes for return address */
-#define FNARGS_STACK_ALIGNMENT_MASK 7
-static const char *const REG_NAMES[MAX_FNARGS_IN_REGS] = {
-	"rdi", "rsi", "rdx", "rcx", "r8", "r9"
-};
+
+#define FNARGS_SUPPORT 1
+#define FNARGS_MAX_ARG_REGS 6
+#define FNARGS_STACK_OFF 8 /* 8 bytes for return address */
+#define FNARGS_STACK_ALIGN 8
+
 #elif defined(__aarch64__)
-#define RETSNOOP_SUPPORTS_ARG_CAPTURE 1
-#define MAX_FNARGS_IN_REGS 8
-/* From the AArch64 ABI Function Call Standard: "The next stacked argument
- * address (NSAA) is set to the current stack-pointer value (SP)."
+
+#define FNARGS_SUPPORT 1
+#define FNARGS_MAX_ARG_REGS 8
+/*
+ * From the AArch64 ABI Function Call Standard:
+ * "The next stacked argument address (NSAA) is set to the current stack-pointer value (SP)."
  */
-#define FNARGS_STACK_OFFSET 0
-#define FNARGS_STACK_ALIGNMENT_MASK 15
-static const char *const REG_NAMES[MAX_FNARGS_IN_REGS] = {
-	"x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7"
-};
+#define FNARGS_STACK_OFF 0
+#define FNARGS_STACK_ALIGN 16
+
 #else
-#define MAX_FNARGS_IN_REGS 0
-#define FNARGS_STACK_OFFSET 0
-#define FNARGS_STACK_ALIGNMENT_MASK 0
+
+#define FNARGS_MAX_ARG_REGS 0
+#define FNARGS_STACK_OFF 0
+#define FNARGS_STACK_ALIGN 0
+
 #endif
 
 #define MAX_FNARGS_TOTAL_ARGS_SZ (64 * 1024)	/* maximum total captured args data size */


### PR DESCRIPTION
Rename and refactor bits of function args capture:
  - some naming adjustment;
  - retsnoop.bpf.c: stack pointer fetching should always work, so no need to guard it with arch checks;
  - retsnoop.h: avoid data declaration in a header, instead hard-code arm64-specific register name resolution logic;
  - fnargs.c: use stack alignment in bytes, instead of mask;